### PR TITLE
set default size to 7 as in readme

### DIFF
--- a/gym_go/envs/go_env.py
+++ b/gym_go/envs/go_env.py
@@ -22,7 +22,7 @@ class GoEnv(gym.Env):
     gogame = GoGame()
     govars = govars
 
-    def __init__(self, size, komi=0, reward_method='real'):
+    def __init__(self, size=7, komi=0, reward_method='real'):
         '''
         @param reward_method: either 'heuristic' or 'real'
         heuristic: gives # black pieces - # white pieces.


### PR DESCRIPTION
this allows users to make the env without kwargs (works more easily in a loop with other envs which usually don't need kwargs)