### PR TITLE
fix-bugs

### DIFF
--- a/gym_go/gogame.py
+++ b/gym_go/gogame.py
@@ -60,8 +60,8 @@ def next_state(state, action1d, canonical=False):
         # Add piece
         state[player, action2d[0], action2d[1]] = 1
 
-        # Get adjacent location and check whether the piece will be surrounded by any piece
-        adj_locs, surrounded = state_utils.adj_data(state, action2d)
+        # Get adjacent location and check whether the piece will be surrounded by opponent's piece
+        adj_locs, surrounded = state_utils.adj_data(state, action2d, player)
 
         # Update pieces
         killed_groups = state_utils.update_pieces(state, adj_locs, player)
@@ -118,8 +118,9 @@ def batch_next_states(batch_states, batch_action1d, canonical=False):
     # Add piece
     batch_states[batch_non_pass, batch_non_pass_players, batch_action2d[:, 0], batch_action2d[:, 1]] = 1
 
-    # Get adjacent location and check whether the piece will be surrounded by any piece
-    batch_adj_locs, batch_surrounded = state_utils.batch_adj_data(batch_states[batch_non_pass], batch_action2d)
+    # Get adjacent location and check whether the piece will be surrounded by opponent's piece
+    batch_adj_locs, batch_surrounded = state_utils.batch_adj_data(batch_states[batch_non_pass], batch_action2d,
+                                                                  batch_non_pass_players)
 
     # Update pieces
     batch_killed_groups = state_utils.batch_update_pieces(batch_non_pass, batch_states, batch_adj_locs,

--- a/gym_go/state_utils.py
+++ b/gym_go/state_utils.py
@@ -211,22 +211,22 @@ def batch_update_pieces(batch_non_pass, batch_state, batch_adj_locs, batch_playe
     return batch_killed_groups
 
 
-def adj_data(state, action2d):
+def adj_data(state, action2d, player):
     neighbors = neighbor_deltas + action2d
     valid = (neighbors >= 0) & (neighbors < state.shape[1])
     valid = np.prod(valid, axis=1)
     neighbors = neighbors[np.nonzero(valid)]
 
-    all_pieces = np.sum(state[[govars.BLACK, govars.WHITE]], axis=0)
-    surrounded = (all_pieces[neighbors[:, 0], neighbors[:, 1]] > 0).all()
+    opp_pieces = state[1 - player]
+    surrounded = (opp_pieces[neighbors[:, 0], neighbors[:, 1]] > 0).all()
 
     return neighbors, surrounded
 
 
-def batch_adj_data(batch_state, batch_action2d):
+def batch_adj_data(batch_state, batch_action2d, batch_player):
     batch_neighbors, batch_surrounded = [], []
-    for state, action2d in zip(batch_state, batch_action2d):
-        neighbors, surrounded = adj_data(state, action2d)
+    for state, action2d, player in zip(batch_state, batch_action2d, batch_player):
+        neighbors, surrounded = adj_data(state, action2d, player)
         batch_neighbors.append(neighbors)
         batch_surrounded.append(surrounded)
     return batch_neighbors, batch_surrounded

--- a/gym_go/tests/test_invalid_moves.py
+++ b/gym_go/tests/test_invalid_moves.py
@@ -124,6 +124,42 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         self.assertEqual(np.count_nonzero(state[govars.INVD_CHNL] == 1), 5)
         self.assertEqual(state[govars.INVD_CHNL, 0, 0], 0)
 
+    def test_single_kill_no_ko_protection(self):
+        """
+        Thanks to DeepGeGe for finding this bug.
+
+        _,   _,   _,   _,   2,   1,  13,
+
+        _,   _,   _,   _,   4,   3,  12/14,
+
+        _,   _,   _,   _,   6,   5,   7,
+
+        _,   _,   _,   _,   _,   8,  10,
+
+        _,   _,   _,   _,   _,   _,   _,
+
+        _,   _,   _,   _,   _,   _,   _,
+
+        _,   _,   _,   _,   _,   _,   _,
+
+        :return:
+        """
+
+        for move in [(0, 5), (0, 4), (1, 5), (1, 4), (2, 5), (2, 4), (2, 6), (3, 5), None, (3, 6), None, (1, 6),
+                     (0, 6)]:
+            state, reward, done, info = self.env.step(move)
+
+        # Test final kill move (1, 6) is valid
+        final_move = (1, 6)
+        self.assertEqual(state[govars.INVD_CHNL, 1, 6], 0)
+        state, _, _, _ = self.env.step(final_move)
+
+        # Assert black is removed
+        self.assertEqual(state[govars.BLACK].sum(), 0)
+
+        # Assert 6 white pieces still on the board
+        self.assertEqual(state[govars.WHITE].sum(), 6)    
+        
     def test_invalid_no_liberty_move(self):
         """
         _,   1,   2,   _,   _,   _,   _,


### PR DESCRIPTION
There are two serious bugs in function adj_data and batch_adj_data when to determine a point is protected by ko or not. If only killed one group, and that one group was one piece, and piece set is surrounded by opponent's piece, activate ko protection, instead of any piece.
If only need to be surrounded by any piece, the point in the piecture bellow will protected by ko, but it's against the rules of go.
![1](https://user-images.githubusercontent.com/51083814/118361452-16734980-b5be-11eb-84a6-133c8f1cc977.png)
![2](https://user-images.githubusercontent.com/51083814/118361456-1a06d080-b5be-11eb-85f0-53fffd41c1ac.png)
