### PR TITLE
Explicitly specify gym version 0.20.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 setup(
     name='gym_go',
     version='0.0.1',
-    install_requires=['gym']  # and other dependencies
+    install_requires=['gym==0.20.0']  # and other dependencies
 )


### PR DESCRIPTION
[OpenAI Gym](https://github.com/openai/gym) has a number of [breaking changes](https://github.com/openai/gym/releases). This gym isn't yet compatible with them, so let's specify the latest version that works.

## Steps to reproduce
1. `git checkout master`
2. Install packages in an isolated venv:

```shell
rm -r screenshots # interferes with packaging process
pipenv install -e .
pipenv install pyglet scipy sklearn
pipenv shell
python demo.py
```

3. You should see an error initialising the gym: `gym.error.NameNotFound: Environment 'gym_go:go' doesn't exist.`

4. Reset the repository and check out this branch:

```shell
pipenv --rm
rm -r Pipfile* build
```

5. Repeat this process
6. The demo should start

