### PR TITLE
Upgrade gym to 0.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ pip install -e .
 ### Coding example
 ```python
 import gym
+import gym_go
 
-go_env = gym.make('gym_go:go-v0', size=7, komi=0, reward_method='real')
+go_env = gym.make('go-v0', size=7, komi=0, reward_method='real')
 go_env.reset()
 
 first_action = (2,5)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ pip install -e .
 import gym
 
 go_env = gym.make('gym_go:go-v0', size=7, komi=0, reward_method='real')
+go_env.reset()
 
 first_action = (2,5)
 second_action = (5,2)

--- a/demo.py
+++ b/demo.py
@@ -10,6 +10,7 @@ args = parser.parse_args()
 
 # Initialize environment
 go_env = gym.make('gym_go:go-v0', size=args.boardsize, komi=args.komi)
+go_env.reset()
 
 # Game loop
 done = False

--- a/demo.py
+++ b/demo.py
@@ -1,6 +1,7 @@
 import argparse
 
 import gym
+import gym_go
 
 # Arguments
 parser = argparse.ArgumentParser(description='Demo Go Environment')
@@ -9,7 +10,7 @@ parser.add_argument('--komi', type=float, default=0)
 args = parser.parse_args()
 
 # Initialize environment
-go_env = gym.make('gym_go:go-v0', size=args.boardsize, komi=args.komi)
+go_env = gym.make('go-v0', size=args.boardsize, komi=args.komi)
 go_env.reset()
 
 # Game loop

--- a/gym_go/tests/efficiency.py
+++ b/gym_go/tests/efficiency.py
@@ -2,6 +2,7 @@ import time
 import unittest
 
 import gym
+import gym_go
 import numpy as np
 from tqdm import tqdm
 
@@ -11,7 +12,7 @@ class Efficiency(unittest.TestCase):
     iterations = 64
 
     def setUp(self) -> None:
-        self.env = gym.make('gym_go:go-v0', size=self.boardsize, reward_method='real')
+        self.env = gym.make('go-v0', size=self.boardsize, reward_method='real')
 
     def testOrderedTrajs(self):
         durs = []

--- a/gym_go/tests/test_basics.py
+++ b/gym_go/tests/test_basics.py
@@ -10,13 +10,13 @@ class TestGoEnvBasics(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.env = gym.make('gym_go:go-v0', size=7, reward_method='real')
+        self.env = gym.make('go-v0', size=7, reward_method='real')
 
     def setUp(self):
         self.env.reset()
 
     def test_state(self):
-        env = gym.make('gym_go:go-v0', size=7)
+        env = gym.make('go-v0', size=7)
         state = env.reset()
         self.assertIsInstance(state, np.ndarray)
         self.assertEqual(state.shape[0], govars.NUM_CHNLS)
@@ -27,7 +27,7 @@ class TestGoEnvBasics(unittest.TestCase):
         expected_sizes = [7, 13, 19]
 
         for expec_size in expected_sizes:
-            env = gym.make('gym_go:go-v0', size=expec_size)
+            env = gym.make('go-v0', size=expec_size)
             state = env.reset()
             self.assertEqual(state.shape[1], expec_size)
             self.assertEqual(state.shape[2], expec_size)
@@ -150,7 +150,7 @@ class TestGoEnvBasics(unittest.TestCase):
         self.assertFalse(done)
 
     def test_num_liberties(self):
-        env = gym.make('gym_go:go-v0', size=7)
+        env = gym.make('go-v0', size=7)
 
         steps = [(0, 0), (0, 1)]
         libs = [(2, 0), (1, 2)]
@@ -173,7 +173,7 @@ class TestGoEnvBasics(unittest.TestCase):
             self.assertEqual(whitelibs, libs[1], state)
 
     def test_komi(self):
-        env = gym.make('gym_go:go-v0', size=7, komi=2.5, reward_method='real')
+        env = gym.make('go-v0', size=7, komi=2.5, reward_method='real')
         env.reset()
 
         # White win
@@ -224,7 +224,7 @@ class TestGoEnvBasics(unittest.TestCase):
                     self.assertTrue((children[a] == 0).all())
 
     def test_real_reward(self):
-        env = gym.make('gym_go:go-v0', size=7, reward_method='real')
+        env = gym.make('go-v0', size=7, reward_method='real')
         env.reset()
 
         # In game
@@ -260,7 +260,7 @@ class TestGoEnvBasics(unittest.TestCase):
         env.close()
 
     def test_heuristic_reward(self):
-        env = gym.make('gym_go:go-v0', size=7, reward_method='heuristic')
+        env = gym.make('go-v0', size=7, reward_method='heuristic')
         env.reset()
 
         # In game

--- a/gym_go/tests/test_basics.py
+++ b/gym_go/tests/test_basics.py
@@ -174,6 +174,7 @@ class TestGoEnvBasics(unittest.TestCase):
 
     def test_komi(self):
         env = gym.make('gym_go:go-v0', size=7, komi=2.5, reward_method='real')
+        env.reset()
 
         # White win
         _ = env.step(None)
@@ -224,6 +225,7 @@ class TestGoEnvBasics(unittest.TestCase):
 
     def test_real_reward(self):
         env = gym.make('gym_go:go-v0', size=7, reward_method='real')
+        env.reset()
 
         # In game
         state, reward, done, info = env.step((0, 0))
@@ -259,6 +261,7 @@ class TestGoEnvBasics(unittest.TestCase):
 
     def test_heuristic_reward(self):
         env = gym.make('gym_go:go-v0', size=7, reward_method='heuristic')
+        env.reset()
 
         # In game
         state, reward, done, info = env.step((0, 0))

--- a/gym_go/tests/test_invalid_moves.py
+++ b/gym_go/tests/test_invalid_moves.py
@@ -186,6 +186,7 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         """
 
         self.env = gym.make('gym_go:go-v0', size=3, reward_method='real')
+        self.env.reset()
         for move in [6, 7, 8, 5, 4, 8, 0, 1]:
             state, reward, done, info = self.env.step(move)
 
@@ -203,6 +204,7 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         """
 
         self.env = gym.make('gym_go:go-v0', size=3, reward_method='real')
+        self.env.reset()
         for move in [0, 8, 6, 4, 1, 2, 3, 7]:
             state, reward, done, info = self.env.step(move)
 

--- a/gym_go/tests/test_invalid_moves.py
+++ b/gym_go/tests/test_invalid_moves.py
@@ -11,7 +11,7 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.env = gym.make('gym_go:go-v0', size=7, reward_method='real')
+        self.env = gym.make('go-v0', size=7, reward_method='real')
 
     def setUp(self):
         self.env.reset()
@@ -185,7 +185,7 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         :return:
         """
 
-        self.env = gym.make('gym_go:go-v0', size=3, reward_method='real')
+        self.env = gym.make('go-v0', size=3, reward_method='real')
         self.env.reset()
         for move in [6, 7, 8, 5, 4, 8, 0, 1]:
             state, reward, done, info = self.env.step(move)
@@ -203,7 +203,7 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         :return:
         """
 
-        self.env = gym.make('gym_go:go-v0', size=3, reward_method='real')
+        self.env = gym.make('go-v0', size=3, reward_method='real')
         self.env.reset()
         for move in [0, 8, 6, 4, 1, 2, 3, 7]:
             state, reward, done, info = self.env.step(move)

--- a/gym_go/tests/test_valid_moves.py
+++ b/gym_go/tests/test_valid_moves.py
@@ -10,7 +10,7 @@ class TestGoEnvValidMoves(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.env = gym.make('gym_go:go-v0', size=7, reward_method='real')
+        self.env = gym.make('go-v0', size=7, reward_method='real')
 
     def setUp(self):
         self.env.reset()

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 setup(
     name='gym_go',
     version='0.0.1',
-    install_requires=['gym==0.21.0']  # and other dependencies
+    install_requires=['gym==0.22.0']  # and other dependencies
 )

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 setup(
     name='gym_go',
     version='0.0.1',
-    install_requires=['gym']  # and other dependencies
+    install_requires=['gym==0.20.0']  # and other dependencies
 )

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 setup(
     name='gym_go',
     version='0.0.1',
-    install_requires=['gym==0.20.0']  # and other dependencies
+    install_requires=['gym==0.21.0']  # and other dependencies
 )


### PR DESCRIPTION
This PR is based on the following, which should be reviewed and merged first:
- [ ] #15
- [ ] #16

Continue the incremental upgrade path by upgrading gym to 0.22.0. In this release, `gym.make()` no longer accepts the gym's package name. So far we've done this:

```python
env = gym.make('gym_go:go-v0')
```

But now we need to:

```python
import gym_go
env = gym.make('go-v0')
```

