### PR TITLE
Fix bug: When game is over, all moves should be invalid

### DIFF
--- a/gym_go/gogame.py
+++ b/gym_go/gogame.py
@@ -153,7 +153,7 @@ def batch_next_states(batch_states, batch_action1d, canonical=False):
 def invalid_moves(state):
     # return a fixed size binary vector
     if game_ended(state):
-        return np.zeros(action_size(state))
+        return np.ones(action_size(state))
     return np.append(state[govars.INVD_CHNL].flatten(), 0)
 
 

--- a/gym_go/tests/test_invalid_moves.py
+++ b/gym_go/tests/test_invalid_moves.py
@@ -4,7 +4,7 @@ import unittest
 import gym
 import numpy as np
 
-from gym_go import govars
+from gym_go import govars, gogame
 
 
 class TestGoEnvInvalidMoves(unittest.TestCase):
@@ -174,6 +174,8 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
 
         with self.assertRaises(Exception):
             self.env.step((0, 0))
+
+        self.assertTrue((gogame.invalid_moves(self.env.state()) == 1).all())
 
     def test_small_suicide(self):
         """


### PR DESCRIPTION
Currently the `gogame.invalid_moves()` function will return all zeros when the game is over, which indicates that any move is valid. We'd like to indicate the opposite, so return all ones instead.
