### PR TITLE
Super ko

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ pip install -e .
 ### Coding example
 ```python
 import gym
+import gym_go
 
-go_env = gym.make('gym_go:go-v0', size=7, komi=0, reward_method='real')
+go_env = gym.make('go-v0', size=7, komi=0, reward_method='real')
 go_env.reset()
 
 first_action = (2,5)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # About
-An environment for the board game Go. It is implemented using OpenAI's Gym API. 
+An environment for the board game Go. It is implemented using OpenAI's Gym API.
 It is also optimized to be as efficient as possible in order to efficiently train ML models.
 
 # Installation
@@ -25,7 +25,7 @@ go_env.render('terminal')
 ```
 
 ```
-     0 1 2 3 4 5 6 
+     0 1 2 3 4 5 6
 0    ╔═╤═╤═╤═╤═╤═╗
 1    ╟─┼─┼─┼─┼─┼─╢
 2    ╟─┼─┼─┼─┼─○─╢
@@ -43,7 +43,7 @@ go_env.render('terminal')
 ```
 
 ```
-	0 1 2 3 4 5 6 
+	0 1 2 3 4 5 6
 0	╔═╤═╤═╤═╤═╤═╗
 1	╟─┼─┼─┼─┼─┼─╢
 2	╟─┼─┼─┼─┼─○─╢
@@ -64,21 +64,21 @@ python3 demo.py
 ![alt text](screenshots/human_ui.png)
 
 ### High level API
-[GoEnv](gym_go/envs/go_env.py) defines the Gym environment for Go. 
-It contains the highest level API for basic Go usage.  
+[GoEnv](gym_go/envs/go_env.py) defines the Gym environment for Go.
+It contains the highest level API for basic Go usage.
 
 ### Low level API
 [GoGame](gym_go/gogame.py) is the set of low-level functions that defines all the game logic of Go.
 `GoEnv`'s high level API is built on `GoGame`.
-These sets of functions are intended for a more detailed and finetuned 
+These sets of functions are intended for a more detailed and finetuned
 usage of Go.
 
 # Scoring
-We use Trump Taylor scoring, a simple area scoring, to determine the winner. A player's _area_ is defined as the number of empty points a 
-player's pieces surround plus the number of player's pieces on the board. The _winner_ is the player with the larger 
+We use Trump Taylor scoring, a simple area scoring, to determine the winner. A player's _area_ is defined as the number of empty points a
+player's pieces surround plus the number of player's pieces on the board. The _winner_ is the player with the larger
 area (a game is tied if both players have an equal amount of area on the board).
 
-There is also support for `komi`, a bias score constant to balance the advantage of black going first. 
+There is also support for `komi`, a bias score constant to balance the advantage of black going first.
 By default `komi` is set to 0.
 
 # Game ending
@@ -92,16 +92,16 @@ Reward methods are in _black_'s perspective
     * `0` - Game is tied
     * `1` - Black won
   * `0` - Otherwise
-* **Heuristic**: If the game is ongoing, the reward is `black area - white area`. 
-If black won, the reward is `BOARD_SIZE**2`. 
+* **Heuristic**: If the game is ongoing, the reward is `black area - white area`.
+If black won, the reward is `BOARD_SIZE**2`.
 If white won, the reward is `-BOARD_SIZE**2`.
 If tied, the reward is `0`.
 
 # State
-The `state` object that is returned by the `reset` and `step` functions of the environment is a 
-`6 x BOARD_SIZE x BOARD_SIZE` numpy array. All values in the array are either `0` or `1` 
+The `state` object that is returned by the `reset` and `step` functions of the environment is a
+`6 x BOARD_SIZE x BOARD_SIZE` numpy array. All values in the array are either `0` or `1`
 * **First and second channel:** represent the black and white pieces respectively.
-* **Third channel:** Indicator layer for whose turn it is 
+* **Third channel:** Indicator layer for whose turn it is
 * **Fourth channel:** Invalid moves (including ko-protection) for the next action
 * **Fifth channel:** Indicator layer for whether the previous move was a pass
 * **Sixth channel:** Indicator layer for whether the game is over

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ area (a game is tied if both players have an equal amount of area on the board).
 There is also support for `komi`, a bias score constant to balance the advantage of black going first.
 By default `komi` is set to 0.
 
+# Ko and super ko
+The game supports a simple implementation of the ko rule by default, which prevents single move take-back scenarios. In addition, an optional
+super ko rule can be enabled when initializing the gym:
+
+```python
+go_env = gym.make('go-v0', size=7, super_ko=True)
+```
+
+This rule implements positional super ko by tracking play history, which catches repeating positions not detected by the regular ko rule
+at the price of a performance overhead.
+
 # Game ending
 A game ends when both players pass consecutively
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ pip install -e .
 import gym
 
 go_env = gym.make('gym_go:go-v0', size=7, komi=0, reward_method='real')
+go_env.reset()
 
 first_action = (2,5)
 second_action = (5,2)

--- a/demo.py
+++ b/demo.py
@@ -10,6 +10,7 @@ args = parser.parse_args()
 
 # Initialize environment
 go_env = gym.make('gym_go:go-v0', size=args.boardsize, komi=args.komi)
+go_env.reset()
 
 # Game loop
 done = False

--- a/demo.py
+++ b/demo.py
@@ -1,6 +1,7 @@
 import argparse
 
 import gym
+import gym_go
 
 # Arguments
 parser = argparse.ArgumentParser(description='Demo Go Environment')
@@ -9,7 +10,7 @@ parser.add_argument('--komi', type=float, default=0)
 args = parser.parse_args()
 
 # Initialize environment
-go_env = gym.make('gym_go:go-v0', size=args.boardsize, komi=args.komi)
+go_env = gym.make('go-v0', size=args.boardsize, komi=args.komi)
 go_env.reset()
 
 # Game loop

--- a/gym_go/envs/go_env.py
+++ b/gym_go/envs/go_env.py
@@ -62,7 +62,7 @@ class GoEnv(gym.Env):
             action = self.size ** 2
 
         self.old_state = self.state()
-        self.state_ = gogame.next_state(self.state_, action, canonical=False)
+        self.state_ = gogame.next_state(self.state_, action, canonical=False, history=self.history)
         self.history.append(self.old_state)
         self.done = gogame.game_ended(self.state_)
         return np.copy(self.state_), self.reward(), self.done, self.info()

--- a/gym_go/envs/go_env.py
+++ b/gym_go/envs/go_env.py
@@ -31,6 +31,7 @@ class GoEnv(gym.Env):
         self.size = size
         self.komi = komi
         self.state_ = gogame.init_state(size)
+        self.history = []
         self.reward_method = RewardMethod(reward_method)
         self.observation_space = gym.spaces.Box(np.float32(0), np.float32(govars.NUM_CHNLS),
                                                 shape=(govars.NUM_CHNLS, size, size))
@@ -43,6 +44,7 @@ class GoEnv(gym.Env):
         done, return state
         '''
         self.state_ = gogame.init_state(self.size)
+        self.history = []
         self.done = False
         return np.copy(self.state_)
 
@@ -59,7 +61,9 @@ class GoEnv(gym.Env):
         elif action is None:
             action = self.size ** 2
 
+        self.old_state = self.state()
         self.state_ = gogame.next_state(self.state_, action, canonical=False)
+        self.history.append(self.old_state)
         self.done = gogame.game_ended(self.state_)
         return np.copy(self.state_), self.reward(), self.done, self.info()
 

--- a/gym_go/gogame.py
+++ b/gym_go/gogame.py
@@ -247,7 +247,7 @@ def turn(state):
 
 
 def batch_turn(batch_state):
-    return np.max(batch_state[:, govars.TURN_CHNL], axis=(1, 2)).astype(np.int)
+    return np.max(batch_state[:, govars.TURN_CHNL], axis=(1, 2)).astype(int)
 
 
 def liberties(state: np.ndarray):
@@ -258,7 +258,7 @@ def liberties(state: np.ndarray):
     liberty_list = []
     for player_pieces in [blacks, whites]:
         liberties = ndimage.binary_dilation(player_pieces, state_utils.surround_struct)
-        liberties *= (1 - all_pieces).astype(np.bool)
+        liberties *= (1 - all_pieces).astype(bool)
         liberty_list.append(liberties)
 
     return liberty_list[0], liberty_list[1]

--- a/gym_go/gogame.py
+++ b/gym_go/gogame.py
@@ -31,7 +31,7 @@ def batch_init_state(batch_size, board_size):
     return batch_state
 
 
-def next_state(state, action1d, canonical=False):
+def next_state(state, action1d, canonical=False, history=None):
     # Deep copy the state to modify
     state = np.copy(state)
 
@@ -75,7 +75,7 @@ def next_state(state, action1d, canonical=False):
                 ko_protect = killed_group[0]
 
     # Update invalid moves
-    state[govars.INVD_CHNL] = state_utils.compute_invalid_moves(state, player, ko_protect)
+    state[govars.INVD_CHNL] = state_utils.compute_invalid_moves(state, player, ko_protect, history)
 
     # Switch turn
     state_utils.set_turn(state)
@@ -87,7 +87,7 @@ def next_state(state, action1d, canonical=False):
     return state
 
 
-def batch_next_states(batch_states, batch_action1d, canonical=False):
+def batch_next_states(batch_states, batch_action1d, canonical=False, batch_histories=None):
     # Deep copy the state to modify
     batch_states = np.copy(batch_states)
 
@@ -138,7 +138,7 @@ def batch_next_states(batch_states, batch_action1d, canonical=False):
 
     # Update invalid moves
     batch_states[:, govars.INVD_CHNL] = state_utils.batch_compute_invalid_moves(batch_states, batch_players,
-                                                                                batch_ko_protect)
+                                                                                batch_ko_protect, batch_histories)
 
     # Switch turn
     state_utils.batch_set_turn(batch_states)

--- a/gym_go/gogame.py
+++ b/gym_go/gogame.py
@@ -74,11 +74,11 @@ def next_state(state, action1d, canonical=False, history=None):
             if len(killed_group) == 1:
                 ko_protect = killed_group[0]
 
-    # Update invalid moves
-    state[govars.INVD_CHNL] = state_utils.compute_invalid_moves(state, player, ko_protect, history)
-
     # Switch turn
     state_utils.set_turn(state)
+
+    # Update invalid moves
+    state[govars.INVD_CHNL] = state_utils.compute_invalid_moves(state, player, ko_protect, history)
 
     if canonical:
         # Set canonical form
@@ -136,12 +136,12 @@ def batch_next_states(batch_states, batch_action1d, canonical=False, batch_histo
             if len(killed_group) == 1:
                 batch_ko_protect[batch_non_pass[i]] = killed_group[0]
 
+    # Switch turn
+    state_utils.batch_set_turn(batch_states)
+
     # Update invalid moves
     batch_states[:, govars.INVD_CHNL] = state_utils.batch_compute_invalid_moves(batch_states, batch_players,
                                                                                 batch_ko_protect, batch_histories)
-
-    # Switch turn
-    state_utils.batch_set_turn(batch_states)
 
     if canonical:
         # Set canonical form

--- a/gym_go/gogame.py
+++ b/gym_go/gogame.py
@@ -153,7 +153,7 @@ def batch_next_states(batch_states, batch_action1d, canonical=False, batch_histo
 def invalid_moves(state):
     # return a fixed size binary vector
     if game_ended(state):
-        return np.zeros(action_size(state))
+        return np.ones(action_size(state))
     return np.append(state[govars.INVD_CHNL].flatten(), 0)
 
 

--- a/gym_go/gogame.py
+++ b/gym_go/gogame.py
@@ -280,7 +280,7 @@ def areas(state):
     all_pieces = np.sum(state[[govars.BLACK, govars.WHITE]], axis=0)
     empties = 1 - all_pieces
 
-    empty_labels, num_empty_areas = ndimage.measurements.label(empties)
+    empty_labels, num_empty_areas = ndimage.label(empties)
 
     black_area, white_area = np.sum(state[govars.BLACK]), np.sum(state[govars.WHITE])
     for label in range(1, num_empty_areas + 1):

--- a/gym_go/state_utils.py
+++ b/gym_go/state_utils.py
@@ -1,6 +1,5 @@
 import numpy as np
 from scipy import ndimage
-from scipy.ndimage import measurements
 
 from gym_go import govars
 
@@ -45,8 +44,8 @@ def compute_invalid_moves(state, player, ko_protect=None):
     definite_valids_array = np.zeros(state.shape[1:])
 
     # Get all groups
-    all_own_groups, num_own_groups = measurements.label(state[player])
-    all_opp_groups, num_opp_groups = measurements.label(state[1 - player])
+    all_own_groups, num_own_groups = ndimage.label(state[player])
+    all_opp_groups, num_opp_groups = ndimage.label(state[1 - player])
     expanded_own_groups = np.zeros((num_own_groups, *state.shape[1:]))
     expanded_opp_groups = np.zeros((num_opp_groups, *state.shape[1:]))
 
@@ -108,8 +107,8 @@ def batch_compute_invalid_moves(batch_state, batch_player, batch_ko_protect):
     batch_definite_valids_array = np.zeros(batch_state.shape[:1] + batch_state.shape[2:])
 
     # Get all groups
-    batch_all_own_groups, _ = measurements.label(batch_state[batch_idcs, batch_player], group_struct)
-    batch_all_opp_groups, _ = measurements.label(batch_state[batch_idcs, 1 - batch_player], group_struct)
+    batch_all_own_groups, _ = ndimage.label(batch_state[batch_idcs, batch_player], group_struct)
+    batch_all_opp_groups, _ = ndimage.label(batch_state[batch_idcs, 1 - batch_player], group_struct)
 
     batch_data = enumerate(zip(batch_all_own_groups, batch_all_opp_groups, batch_empties))
     for i, (all_own_groups, all_opp_groups, empties) in batch_data:
@@ -163,7 +162,7 @@ def update_pieces(state, adj_locs, player):
     all_pieces = np.sum(state[[govars.BLACK, govars.WHITE]], axis=0)
     empties = 1 - all_pieces
 
-    all_opp_groups, _ = ndimage.measurements.label(state[opponent])
+    all_opp_groups, _ = ndimage.label(state[opponent])
 
     # Go through opponent groups
     all_adj_labels = all_opp_groups[adj_locs[:, 0], adj_locs[:, 1]]
@@ -187,7 +186,7 @@ def batch_update_pieces(batch_non_pass, batch_state, batch_adj_locs, batch_playe
     batch_all_pieces = np.sum(batch_state[:, [govars.BLACK, govars.WHITE]], axis=1)
     batch_empties = 1 - batch_all_pieces
 
-    batch_all_opp_groups, _ = ndimage.measurements.label(batch_state[batch_non_pass, batch_opponent],
+    batch_all_opp_groups, _ = ndimage.label(batch_state[batch_non_pass, batch_opponent],
                                                          group_struct)
 
     batch_data = enumerate(zip(batch_all_opp_groups, batch_all_pieces, batch_empties, batch_adj_locs, batch_opponent))

--- a/gym_go/state_utils.py
+++ b/gym_go/state_utils.py
@@ -20,7 +20,7 @@ surround_struct = np.array([[0, 1, 0],
 neighbor_deltas = np.array([[-1, 0], [1, 0], [0, -1], [0, 1]])
 
 
-def compute_invalid_moves(state, player, ko_protect=None):
+def compute_invalid_moves(state, player, ko_protect=None, history=None):
     """
     Updates invalid moves in the OPPONENT's perspective
     1.) Opponent cannot move at a location
@@ -82,7 +82,7 @@ def compute_invalid_moves(state, player, ko_protect=None):
     return invalid_moves > 0
 
 
-def batch_compute_invalid_moves(batch_state, batch_player, batch_ko_protect):
+def batch_compute_invalid_moves(batch_state, batch_player, batch_ko_protect, batch_history=None):
     """
     Updates invalid moves in the OPPONENT's perspective
     1.) Opponent cannot move at a location

--- a/gym_go/tests/efficiency.py
+++ b/gym_go/tests/efficiency.py
@@ -11,10 +11,32 @@ class Efficiency(unittest.TestCase):
     boardsize = 9
     iterations = 64
 
-    def setUp(self) -> None:
-        self.env = gym.make('go-v0', size=self.boardsize, reward_method='real')
-
     def testOrderedTrajs(self):
+        self.env = gym.make('go-v0', size=self.boardsize, reward_method='real')
+        self.doOrderedTrajs()
+
+    def testOrderedTrajsSuperKo(self):
+        self.env = gym.make('go-v0', size=self.boardsize, reward_method='real', super_ko=True)
+        self.doOrderedTrajs('super ko')
+
+    def testLowerBound(self):
+        self.env = gym.make('go-v0', size=self.boardsize, reward_method='real')
+        self.doLowerBound()
+
+    def testLowerBoundSuperKo(self):
+        self.env = gym.make('go-v0', size=self.boardsize, reward_method='real', super_ko=True)
+        self.doLowerBound('super ko')
+
+    def testRandTrajsWithChildren(self):
+        self.env = gym.make('go-v0', size=self.boardsize, reward_method='real')
+        self.doRandTrajsWithChildren()
+
+    def testRandTrajsWithChildrenSuperKo(self):
+        self.env = gym.make('go-v0', size=self.boardsize, reward_method='real', super_ko=True)
+        self.doRandTrajsWithChildren('super ko')
+
+
+    def doOrderedTrajs(self, msg=''):
         durs = []
         for _ in tqdm(range(self.iterations)):
             start = time.time()
@@ -28,9 +50,12 @@ class Efficiency(unittest.TestCase):
 
         avg_time = np.mean(durs)
         std_time = np.std(durs)
-        print(f"Ordered Trajs: {avg_time:.3f} AVG, {std_time:.3f} STD", flush=True)
+        if msg != '':
+            msg = f' ({msg})'
+        print(f"Ordered Trajs{msg}: {avg_time:.3f} AVG, {std_time:.3f} STD", flush=True)
 
-    def testLowerBound(self):
+
+    def doLowerBound(self, msg=''):
         durs = []
         for _ in tqdm(range(self.iterations)):
             start = time.time()
@@ -52,9 +77,11 @@ class Efficiency(unittest.TestCase):
 
         avg_time = np.mean(durs)
         std_time = np.std(durs)
-        print(f"Lower bound: {avg_time:.3f} AVG, {std_time:.3f} STD", flush=True)
+        if msg != '':
+            msg = f' ({msg})'
+        print(f"Lower bound{msg}: {avg_time:.3f} AVG, {std_time:.3f} STD", flush=True)
 
-    def testRandTrajsWithChildren(self):
+    def doRandTrajsWithChildren(self, msg=''):
         durs = []
         num_steps = []
         for _ in tqdm(range(self.iterations)):
@@ -84,7 +111,9 @@ class Efficiency(unittest.TestCase):
         avg_time = np.mean(durs)
         std_time = np.std(durs)
         avg_steps = np.mean(num_steps)
-        print(f"Rand Trajs w/ Children: {avg_time:.3f} AVG SEC, {std_time:.3f} STD SEC, {avg_steps:.1f} AVG STEPS",
+        if msg != '':
+            msg = f' ({msg})'
+        print(f"Rand Trajs w/ Children{msg}: {avg_time:.3f} AVG SEC, {std_time:.3f} STD SEC, {avg_steps:.1f} AVG STEPS",
               flush=True)
 
 

--- a/gym_go/tests/efficiency.py
+++ b/gym_go/tests/efficiency.py
@@ -2,6 +2,7 @@ import time
 import unittest
 
 import gym
+import gym_go
 import numpy as np
 from tqdm import tqdm
 
@@ -11,7 +12,7 @@ class Efficiency(unittest.TestCase):
     iterations = 64
 
     def setUp(self) -> None:
-        self.env = gym.make('gym_go:go-v0', size=self.boardsize, reward_method='real')
+        self.env = gym.make('go-v0', size=self.boardsize, reward_method='real')
 
     def testOrderedTrajs(self):
         durs = []

--- a/gym_go/tests/test_basics.py
+++ b/gym_go/tests/test_basics.py
@@ -10,13 +10,13 @@ class TestGoEnvBasics(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.env = gym.make('gym_go:go-v0', size=7, reward_method='real')
+        self.env = gym.make('go-v0', size=7, reward_method='real')
 
     def setUp(self):
         self.env.reset()
 
     def test_state(self):
-        env = gym.make('gym_go:go-v0', size=7)
+        env = gym.make('go-v0', size=7)
         state = env.reset()
         self.assertIsInstance(state, np.ndarray)
         self.assertEqual(state.shape[0], govars.NUM_CHNLS)
@@ -27,7 +27,7 @@ class TestGoEnvBasics(unittest.TestCase):
         expected_sizes = [7, 13, 19]
 
         for expec_size in expected_sizes:
-            env = gym.make('gym_go:go-v0', size=expec_size)
+            env = gym.make('go-v0', size=expec_size)
             state = env.reset()
             self.assertEqual(state.shape[1], expec_size)
             self.assertEqual(state.shape[2], expec_size)
@@ -150,7 +150,7 @@ class TestGoEnvBasics(unittest.TestCase):
         self.assertFalse(done)
 
     def test_num_liberties(self):
-        env = gym.make('gym_go:go-v0', size=7)
+        env = gym.make('go-v0', size=7)
 
         steps = [(0, 0), (0, 1)]
         libs = [(2, 0), (1, 2)]
@@ -173,7 +173,7 @@ class TestGoEnvBasics(unittest.TestCase):
             self.assertEqual(whitelibs, libs[1], state)
 
     def test_komi(self):
-        env = gym.make('gym_go:go-v0', size=7, komi=2.5, reward_method='real')
+        env = gym.make('go-v0', size=7, komi=2.5, reward_method='real')
         env.reset()
 
         # White win
@@ -224,7 +224,7 @@ class TestGoEnvBasics(unittest.TestCase):
                     self.assertTrue((children[a] == 0).all())
 
     def test_real_reward(self):
-        env = gym.make('gym_go:go-v0', size=7, reward_method='real')
+        env = gym.make('go-v0', size=7, reward_method='real')
         env.reset()
 
         # In game
@@ -260,7 +260,7 @@ class TestGoEnvBasics(unittest.TestCase):
         env.close()
 
     def test_heuristic_reward(self):
-        env = gym.make('gym_go:go-v0', size=7, reward_method='heuristic')
+        env = gym.make('go-v0', size=7, reward_method='heuristic')
         env.reset()
 
         # In game

--- a/gym_go/tests/test_basics.py
+++ b/gym_go/tests/test_basics.py
@@ -174,6 +174,7 @@ class TestGoEnvBasics(unittest.TestCase):
 
     def test_komi(self):
         env = gym.make('gym_go:go-v0', size=7, komi=2.5, reward_method='real')
+        env.reset()
 
         # White win
         _ = env.step(None)
@@ -224,6 +225,7 @@ class TestGoEnvBasics(unittest.TestCase):
 
     def test_real_reward(self):
         env = gym.make('gym_go:go-v0', size=7, reward_method='real')
+        env.reset()
 
         # In game
         state, reward, done, info = env.step((0, 0))
@@ -259,6 +261,7 @@ class TestGoEnvBasics(unittest.TestCase):
 
     def test_heuristic_reward(self):
         env = gym.make('gym_go:go-v0', size=7, reward_method='heuristic')
+        env.reset()
 
         # In game
         state, reward, done, info = env.step((0, 0))

--- a/gym_go/tests/test_invalid_moves.py
+++ b/gym_go/tests/test_invalid_moves.py
@@ -170,7 +170,7 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         :return:
         """
 
-        self.env = gym.make('go-v0', size=2, reward_method='real')
+        self.env = gym.make('go-v0', size=2, super_ko=True, reward_method='real')
         self.env.reset()
 
         for move in [(0, 0), (1, 1), (1, 0), (0, 1), (0, 0), (1, 0)]:
@@ -192,6 +192,24 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         final_move = (0, 0)
         with self.assertRaises(Exception):
             self.env.step(final_move)
+
+    def test_valid_when_super_ko_disabled(self):
+        self.env = gym.make('go-v0', size=2, super_ko=False, reward_method='real')
+        self.env.reset()
+
+        for move in [(0, 0), (1, 1), (1, 0), (0, 1), (0, 0), (1, 0)]:
+            state, reward, done, info = self.env.step(move)
+
+        # Test invalid channel
+        self.assertEqual(
+            np.count_nonzero(state[govars.INVD_CHNL]),
+            3,
+            state[govars.INVD_CHNL]
+        )
+        self.assertEqual(np.count_nonzero(state[govars.INVD_CHNL] == 1), 3)
+        self.assertEqual(state[govars.INVD_CHNL, 0, 0], 0)
+
+        self.env.step((0, 0))
 
     def test_invalid_game_already_over_move(self):
         self.env.step(None)

--- a/gym_go/tests/test_invalid_moves.py
+++ b/gym_go/tests/test_invalid_moves.py
@@ -186,6 +186,7 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         """
 
         self.env = gym.make('gym_go:go-v0', size=3, reward_method='real')
+        self.env.reset()
         for move in [6, 7, 8, 5, 4, 8, 0, 1]:
             state, reward, done, info = self.env.step(move)
 
@@ -203,6 +204,7 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         """
 
         self.env = gym.make('gym_go:go-v0', size=3, reward_method='real')
+        self.env.reset()
         for move in [0, 8, 6, 4, 1, 2, 3, 7]:
             state, reward, done, info = self.env.step(move)
 

--- a/gym_go/tests/test_invalid_moves.py
+++ b/gym_go/tests/test_invalid_moves.py
@@ -11,7 +11,7 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.env = gym.make('gym_go:go-v0', size=7, reward_method='real')
+        self.env = gym.make('go-v0', size=7, reward_method='real')
 
     def setUp(self):
         self.env.reset()
@@ -185,7 +185,7 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         :return:
         """
 
-        self.env = gym.make('gym_go:go-v0', size=3, reward_method='real')
+        self.env = gym.make('go-v0', size=3, reward_method='real')
         self.env.reset()
         for move in [6, 7, 8, 5, 4, 8, 0, 1]:
             state, reward, done, info = self.env.step(move)
@@ -203,7 +203,7 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         :return:
         """
 
-        self.env = gym.make('gym_go:go-v0', size=3, reward_method='real')
+        self.env = gym.make('go-v0', size=3, reward_method='real')
         self.env.reset()
         for move in [0, 8, 6, 4, 1, 2, 3, 7]:
             state, reward, done, info = self.env.step(move)

--- a/gym_go/tests/test_invalid_moves.py
+++ b/gym_go/tests/test_invalid_moves.py
@@ -160,6 +160,39 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
         with self.assertRaises(Exception):
             self.env.step(final_move)
 
+
+    def test_invalid_super_ko_move(self):
+        """
+        1/5/7, 3/6,
+
+        4,       2,
+
+        :return:
+        """
+
+        self.env = gym.make('go-v0', size=2, reward_method='real')
+        self.env.reset()
+
+        for move in [(0, 0), (1, 1), (1, 0), (0, 1), (0, 0), (1, 0)]:
+            state, reward, done, info = self.env.step(move)
+
+        # Test invalid channel
+        self.assertEqual(
+            np.count_nonzero(state[govars.INVD_CHNL]),
+            4,
+            state[govars.INVD_CHNL]
+        )
+        self.assertEqual(np.count_nonzero(state[govars.INVD_CHNL] == 1), 4)
+        self.assertEqual(state[govars.INVD_CHNL, 0, 0], 1)
+
+        # Assert pieces channel is empty at ko-protection coordinate
+        self.assertEqual(state[govars.BLACK, 0, 0], 0)
+        self.assertEqual(state[govars.WHITE, 0, 0], 0)
+
+        final_move = (0, 0)
+        with self.assertRaises(Exception):
+            self.env.step(final_move)
+
     def test_invalid_game_already_over_move(self):
         self.env.step(None)
         self.env.step(None)

--- a/gym_go/tests/test_invalid_moves.py
+++ b/gym_go/tests/test_invalid_moves.py
@@ -4,7 +4,7 @@ import unittest
 import gym
 import numpy as np
 
-from gym_go import govars
+from gym_go import govars, gogame
 
 
 class TestGoEnvInvalidMoves(unittest.TestCase):
@@ -174,6 +174,8 @@ class TestGoEnvInvalidMoves(unittest.TestCase):
 
         with self.assertRaises(Exception):
             self.env.step((0, 0))
+
+        self.assertTrue((gogame.invalid_moves(self.env.state()) == 1).all())
 
     def test_small_suicide(self):
         """

--- a/gym_go/tests/test_super_ko.py
+++ b/gym_go/tests/test_super_ko.py
@@ -1,0 +1,29 @@
+import unittest
+
+import gym
+import gym_go
+
+class TestGoEnvSuperKo(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.env = gym.make('go-v0', size=2)
+
+    def setUp(self):
+        self.env.reset()
+
+    def test_initial_history(self):
+        self.assertEqual(self.env.history, [])
+
+    def test_step_builds_history(self):
+        self.env.step((0, 0))
+        self.assertEqual(len(self.env.history), 1)
+
+    def test_reset_clears_history(self):
+        self.env.step((0, 0))
+        self.assertNotEqual(self.env.history, [])
+        self.env.reset()
+        self.assertEqual(self.env.history, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gym_go/tests/test_super_ko.py
+++ b/gym_go/tests/test_super_ko.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 import gym
 import gym_go
 from gym_go import gogame
@@ -34,6 +36,20 @@ class TestGoEnvSuperKo(unittest.TestCase):
         invalid_moves = state_utils.compute_invalid_moves(state, 0, ko_protect=None, history=history)
 
         self.assertTrue((invalid_moves == [[1, 0], [0, 0]]).all())
+
+    def test_batch_invalid_moves(self):
+        """Given an empty board and a history with a move, that same move should be invalid"""
+        state = gogame.init_state(2)
+        history = [gogame.next_state(state, 0)]
+
+        invalid_moves = state_utils.batch_compute_invalid_moves(
+            np.expand_dims(state, 0),
+            np.array([0]),
+            batch_ko_protect=np.array([None]),
+            batch_history=np.expand_dims(history, 0)
+        )
+
+        self.assertTrue((invalid_moves == [[[1, 0], [0, 0]]]).all())
 
 if __name__ == '__main__':
     unittest.main()

--- a/gym_go/tests/test_super_ko.py
+++ b/gym_go/tests/test_super_ko.py
@@ -10,7 +10,7 @@ from gym_go import state_utils
 class TestGoEnvSuperKo(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.env = gym.make('go-v0', size=2)
+        self.env = gym.make('go-v0', size=2, super_ko=True)
 
     def setUp(self):
         self.env.reset()
@@ -18,15 +18,33 @@ class TestGoEnvSuperKo(unittest.TestCase):
     def test_initial_history(self):
         self.assertEqual(self.env.history, [])
 
+    def test_initial_history_no_super_ko(self):
+        self.env = gym.make('go-v0', size=2, super_ko=False)
+        self.assertEqual(self.env.history, None)
+
     def test_step_builds_history(self):
         self.env.step((0, 0))
         self.assertEqual(len(self.env.history), 1)
+
+    def test_step_ignores_history_no_super_ko(self):
+        self.env = gym.make('go-v0', size=2, super_ko=False)
+        self.env.reset()
+        self.env.step((0, 0))
+        self.assertEqual(self.env.history, None)
 
     def test_reset_clears_history(self):
         self.env.step((0, 0))
         self.assertNotEqual(self.env.history, [])
         self.env.reset()
         self.assertEqual(self.env.history, [])
+
+    def test_reset_clears_history_no_super_ko(self):
+        self.env = gym.make('go-v0', size=2, super_ko=False)
+        self.env.reset()
+        self.env.step((0, 0))
+        self.assertEqual(self.env.history, None)
+        self.env.reset()
+        self.assertEqual(self.env.history, None)
 
     def test_invalid_moves(self):
         """Given an empty board and a history with a move, that same move should be invalid"""

--- a/gym_go/tests/test_super_ko.py
+++ b/gym_go/tests/test_super_ko.py
@@ -2,6 +2,8 @@ import unittest
 
 import gym
 import gym_go
+from gym_go import gogame
+from gym_go import state_utils
 
 class TestGoEnvSuperKo(unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -24,6 +26,14 @@ class TestGoEnvSuperKo(unittest.TestCase):
         self.env.reset()
         self.assertEqual(self.env.history, [])
 
+    def test_invalid_moves(self):
+        """Given an empty board and a history with a move, that same move should be invalid"""
+        state = gogame.init_state(2)
+        history = [gogame.next_state(state, 0)]
+
+        invalid_moves = state_utils.compute_invalid_moves(state, 0, ko_protect=None, history=history)
+
+        self.assertTrue((invalid_moves == [[1, 0], [0, 0]]).all())
 
 if __name__ == '__main__':
     unittest.main()

--- a/gym_go/tests/test_valid_moves.py
+++ b/gym_go/tests/test_valid_moves.py
@@ -10,7 +10,7 @@ class TestGoEnvValidMoves(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.env = gym.make('gym_go:go-v0', size=7, reward_method='real')
+        self.env = gym.make('go-v0', size=7, reward_method='real')
 
     def setUp(self):
         self.env.reset()

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 setup(
     name='gym_go',
     version='0.0.1',
-    install_requires=['gym==0.22.0']  # and other dependencies
+    install_requires=['gym==0.23.1']  # and other dependencies
 )

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 setup(
     name='gym_go',
     version='0.0.1',
-    install_requires=['gym==0.21.0']  # and other dependencies
+    install_requires=['gym==0.22.0']  # and other dependencies
 )

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 setup(
     name='gym_go',
     version='0.0.1',
-    install_requires=['gym']  # and other dependencies
+    install_requires=['gym==0.20.0']  # and other dependencies
 )

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup
 setup(
     name='gym_go',
     version='0.0.1',
-    install_requires=['gym==0.20.0']  # and other dependencies
+    install_requires=['gym==0.21.0']  # and other dependencies
 )


### PR DESCRIPTION
This PR is based on the following, which should be reviewed and merged first:
- [ ] #15
- [ ] #16
- [ ] #17
- [ ] #18
- [ ] #19
- [ ] #20

Initial discussion: #13

Implements positional super ko rule, which prevents a board position from being repeated, beyond simple take-back scenarios. This rule is particularly useful for small boards, where it's easy to create multi-step cycles.

The rule is disabled by default, since a) we don't want to change the default behaviour of the gym, and b) it significantly affects performance:

```
❯ python gym_go/tests/efficiency.py
100%|█████████████████████████████████████████████████████| 64/64 [00:00<00:00, 371.53it/s]
Lower bound: 0.003 AVG, 0.000 STD
100%|█████████████████████████████████████████████████████| 64/64 [00:00<00:00, 374.59it/s]
Lower bound (super ko): 0.003 AVG, 0.000 STD
100%|██████████████████████████████████████████████████████| 64/64 [00:01<00:00, 53.18it/s]
Ordered Trajs: 0.019 AVG, 0.000 STD
100%|██████████████████████████████████████████████████████| 64/64 [00:31<00:00,  2.03it/s]
Ordered Trajs (super ko): 0.493 AVG, 0.006 STD
100%|██████████████████████████████████████████████████████| 64/64 [00:32<00:00,  1.96it/s]
Rand Trajs w/ Children: 0.510 AVG SEC, 0.029 STD SEC, 161.0 AVG STEPS
100%|██████████████████████████████████████████████████████| 64/64 [01:10<00:00,  1.11s/it]
Rand Trajs w/ Children (super ko): 1.107 AVG SEC, 0.082 STD SEC, 161.0 AVG STEPS
.
----------------------------------------------------------------------
Ran 6 tests in 136.795s
```